### PR TITLE
Modify mosaic

### DIFF
--- a/data_configs/coco128.yaml
+++ b/data_configs/coco128.yaml
@@ -1,0 +1,43 @@
+# Images and labels direcotry should be relative to train.py
+TRAIN_DIR_IMAGES: '../input/coco_128/train'
+TRAIN_DIR_LABELS: '../input/coco_128/train'
+VALID_DIR_IMAGES: '../input/coco_128/valid'
+VALID_DIR_LABELS: '../input/coco_128/valid'
+TEST_DIR_IMAGES: '../input/coco_128/test' # Optional.
+TEST_DIR_LABELS: '../input/coco_128/test' # Optional
+
+# Class names.
+CLASSES: [
+    '__background__',
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+    'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+    'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+    'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+    'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+    'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+    'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+    'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+    'hair drier', 'toothbrush'
+]
+
+COCO_91_CLASSES: [
+    '__background__', 
+    'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
+    'train', 'truck', 'boat', 'traffic light', 'fire hydrant', 'N/A', 'stop sign',
+    'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+    'elephant', 'bear', 'zebra', 'giraffe', 'N/A', 'backpack', 'umbrella', 'N/A', 'N/A',
+    'handbag', 'tie', 'suitcase', 'frisbee', 'skis', 'snowboard', 'sports ball',
+    'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
+    'bottle', 'N/A', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
+    'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza',
+    'donut', 'cake', 'chair', 'couch', 'potted plant', 'bed', 'N/A', 'dining table',
+    'N/A', 'N/A', 'toilet', 'N/A', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+    'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'N/A', 'book',
+    'clock', 'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush'
+]
+
+# Number of classes (object classes + 1 for background class in Faster RCNN).
+NC: 81
+
+# Whether to save the predictions of the validation set while training.
+SAVE_VALID_PREDICTION_IMAGES: True

--- a/datasets.py
+++ b/datasets.py
@@ -87,6 +87,16 @@ class CustomDataset(Dataset):
         #         print(f"Removing {image_name} image")
         #         self.all_image_paths.remove(image_path)
 
+    def resize(self, im, square=False):
+        if square:
+            im = cv2.resize(im, (self.width, self.height))
+        else:
+            h0, w0 = im.shape[:2]  # orig hw
+            r = self.width / max(h0, w0)  # ratio
+            if r != 1:  # if sizes are not equal
+                im = cv2.resize(im, (int(w0 * r), int(h0 * r)))
+        return im
+
     def load_image_and_labels(self, index):
         image_name = self.all_images[index]
         image_path = os.path.join(self.images_path, image_name)
@@ -95,7 +105,8 @@ class CustomDataset(Dataset):
         image = cv2.imread(image_path)
         # Convert BGR to RGB color format.
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB).astype(np.float32)
-        image_resized = cv2.resize(image, (self.width, self.height))
+        image_resized = self.resize(image)
+        # print(image_resized.shape)
         image_resized /= 255.0
         
         # Capture the corresponding XML file for getting the annotations.
@@ -135,10 +146,10 @@ class CustomDataset(Dataset):
             
             # Resize the bounding boxes according to the
             # desired `width`, `height`.
-            xmin_final = (xmin/image_width)*self.width
-            xmax_final = (xmax/image_width)*self.width
-            ymin_final = (ymin/image_height)*self.height
-            ymax_final = (ymax/image_height)*self.height
+            xmin_final = (xmin/image_width)*image_resized.shape[1]
+            xmax_final = (xmax/image_width)*image_resized.shape[1]
+            ymin_final = (ymin/image_height)*image_resized.shape[0]
+            ymax_final = (ymax/image_height)*image_resized.shape[0]
             
             boxes.append([xmin_final, ymin_final, xmax_final, ymax_final])
         

--- a/datasets.py
+++ b/datasets.py
@@ -259,7 +259,7 @@ class CustomDataset(Dataset):
             result_boxes = result_boxes[
                 np.where((result_boxes[:, 2] - result_boxes[:, 0]) * (result_boxes[:, 3] - result_boxes[:, 1]) > 0)
             ]
-        return result_image/255., torch.tensor(result_boxes), \
+        return result_image, torch.tensor(result_boxes), \
             torch.tensor(np.array(final_classes)), area, iscrowd, dims
 
     def __getitem__(self, idx):

--- a/datasets.py
+++ b/datasets.py
@@ -190,14 +190,7 @@ class CustomDataset(Dataset):
         """ 
         Adapted from: https://www.kaggle.com/shonenkov/oof-evaluation-mixup-efficientdet
         """
-        # image, _, _, _, _, _, _, _ = self.load_image_and_labels(index=index)
-        #orig_image = image.copy()
-        # Resize the image according to the `confg.py` resize.
-        # image = cv2.resize(image, resize_factor)
-        # h, w, c = image.shape
         s = self.img_size
-
-        # xc, yc = [int(random.uniform(h * 0.25, w * 0.75)) for _ in range(2)]  # center x, y
         yc, xc = (int(random.uniform(-x, 2 * s + x)) for x in self.mosaic_border)  # mosaic center x, y
         indices = [index] + [random.randint(0, len(self.all_images) - 1) for _ in range(3)]
 
@@ -213,12 +206,6 @@ class CustomDataset(Dataset):
             )
 
             h, w = image_resized.shape[:2]
-
-            # Resize the current image according to the above resize,
-            # else `result_image[y1a:y2a, x1a:x2a] = image[y1b:y2b, x1b:x2b]`
-            # will give error when image sizes are different.
-
-            # image = cv2.resize(image, resize_factor)
 
             if i == 0:
                 # Create empty image with the above resized image.

--- a/datasets.py
+++ b/datasets.py
@@ -18,10 +18,17 @@ from utils.transforms import (
 # the dataset class
 class CustomDataset(Dataset):
     def __init__(
-        self, images_path, labels_path, 
-        width, height, classes, transforms=None, 
+        self, 
+        images_path, 
+        labels_path, 
+        width, 
+        height, 
+        classes, 
+        transforms=None, 
         use_train_aug=False,
-        train=False, no_mosaic=False
+        train=False, 
+        no_mosaic=False,
+        square_training=False
     ):
         self.transforms = transforms
         self.use_train_aug = use_train_aug
@@ -32,6 +39,7 @@ class CustomDataset(Dataset):
         self.classes = classes
         self.train = train
         self.no_mosaic = no_mosaic
+        self.square_training = square_training
         self.image_file_types = ['*.jpg', '*.jpeg', '*.png', '*.ppm', '*.JPG']
         self.all_image_paths = []
         
@@ -105,7 +113,7 @@ class CustomDataset(Dataset):
         image = cv2.imread(image_path)
         # Convert BGR to RGB color format.
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB).astype(np.float32)
-        image_resized = self.resize(image)
+        image_resized = self.resize(image, square=self.square_training)
         # print(image_resized.shape)
         image_resized /= 255.0
         
@@ -312,28 +320,46 @@ def collate_fn(batch):
 
 # Prepare the final datasets and data loaders.
 def create_train_dataset(
-    train_dir_images, train_dir_labels, 
-    resize_width, resize_height, classes,
+    train_dir_images, 
+    train_dir_labels, 
+    resize_width, 
+    resize_height, 
+    classes,
     use_train_aug=False,
-    no_mosaic=False
+    no_mosaic=False,
+    square_training=False
 ):
     train_dataset = CustomDataset(
-        train_dir_images, train_dir_labels,
-        resize_width, resize_height, classes, 
+        train_dir_images, 
+        train_dir_labels,
+        resize_width, 
+        resize_height, 
+        classes, 
         get_train_transform(),
         use_train_aug=use_train_aug,
-        train=True, no_mosaic=no_mosaic
+        train=True, 
+        no_mosaic=no_mosaic,
+        square_training=square_training
     )
     return train_dataset
 def create_valid_dataset(
-    valid_dir_images, valid_dir_labels, 
-    resize_width, resize_height, classes
+    valid_dir_images, 
+    valid_dir_labels, 
+    resize_width, 
+    resize_height, 
+    classes,
+    square_training=False
 ):
     valid_dataset = CustomDataset(
-        valid_dir_images, valid_dir_labels, 
-        resize_width, resize_height, classes, 
+        valid_dir_images, 
+        valid_dir_labels, 
+        resize_width, 
+        resize_height, 
+        classes, 
         get_valid_transform(),
-        train=False, no_mosaic=True
+        train=False, 
+        no_mosaic=True,
+        square_training=square_training
     )
     return valid_dataset
 

--- a/datasets.py
+++ b/datasets.py
@@ -21,8 +21,7 @@ class CustomDataset(Dataset):
         self, 
         images_path, 
         labels_path, 
-        width, 
-        height, 
+        img_size, 
         classes, 
         transforms=None, 
         use_train_aug=False,
@@ -34,13 +33,12 @@ class CustomDataset(Dataset):
         self.use_train_aug = use_train_aug
         self.images_path = images_path
         self.labels_path = labels_path
-        self.height = height
-        self.width = width
+        self.img_size = img_size
         self.classes = classes
         self.train = train
         self.no_mosaic = no_mosaic
         self.square_training = square_training
-        self.mosaic_border = [-width // 2, -width // 2]
+        self.mosaic_border = [-img_size // 2, -img_size // 2]
         self.image_file_types = ['*.jpg', '*.jpeg', '*.png', '*.ppm', '*.JPG']
         self.all_image_paths = []
         
@@ -98,10 +96,10 @@ class CustomDataset(Dataset):
 
     def resize(self, im, square=False):
         if square:
-            im = cv2.resize(im, (self.width, self.height))
+            im = cv2.resize(im, (self.img_size, self.img_size))
         else:
             h0, w0 = im.shape[:2]  # orig hw
-            r = self.width / max(h0, w0)  # ratio
+            r = self.img_size / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 im = cv2.resize(im, (int(w0 * r), int(h0 * r)))
         return im
@@ -196,7 +194,7 @@ class CustomDataset(Dataset):
         # Resize the image according to the `confg.py` resize.
         # image = cv2.resize(image, resize_factor)
         # h, w, c = image.shape
-        s = self.width
+        s = self.img_size
 
         # xc, yc = [int(random.uniform(h * 0.25, w * 0.75)) for _ in range(2)]  # center x, y
         yc, xc = (int(random.uniform(-x, 2 * s + x)) for x in self.mosaic_border)  # mosaic center x, y
@@ -274,7 +272,7 @@ class CustomDataset(Dataset):
             #while True:
             image_resized, boxes, labels, \
                 area, iscrowd, dims = self.load_cutmix_image_and_boxes(
-                idx, resize_factor=(self.height, self.width)
+                idx, resize_factor=(self.img_size, self.img_size)
             )
                 # Only needed if we don't allow training without target bounding boxes
                # if len(boxes) > 0:
@@ -327,8 +325,7 @@ def collate_fn(batch):
 def create_train_dataset(
     train_dir_images, 
     train_dir_labels, 
-    resize_width, 
-    resize_height, 
+    img_size, 
     classes,
     use_train_aug=False,
     no_mosaic=False,
@@ -337,8 +334,7 @@ def create_train_dataset(
     train_dataset = CustomDataset(
         train_dir_images, 
         train_dir_labels,
-        resize_width, 
-        resize_height, 
+        img_size, 
         classes, 
         get_train_transform(),
         use_train_aug=use_train_aug,
@@ -350,16 +346,14 @@ def create_train_dataset(
 def create_valid_dataset(
     valid_dir_images, 
     valid_dir_labels, 
-    resize_width, 
-    resize_height, 
+    img_size, 
     classes,
     square_training=False
 ):
     valid_dataset = CustomDataset(
         valid_dir_images, 
         valid_dir_labels, 
-        resize_width, 
-        resize_height, 
+        img_size, 
         classes, 
         get_valid_transform(),
         train=False, 

--- a/train.py
+++ b/train.py
@@ -218,14 +218,12 @@ def main(args):
     yaml_save(file_path=os.path.join(OUT_DIR, 'opt.yaml'), data=args)
 
     # Model configurations
-    IMAGE_WIDTH = args['img_size']
-    IMAGE_HEIGHT = args['img_size']
+    IMAGE_SIZE = args['img_size']
     
     train_dataset = create_train_dataset(
         TRAIN_DIR_IMAGES, 
         TRAIN_DIR_LABELS,
-        IMAGE_WIDTH, 
-        IMAGE_HEIGHT, 
+        IMAGE_SIZE, 
         CLASSES,
         use_train_aug=args['use_train_aug'],
         no_mosaic=args['no_mosaic'],
@@ -234,8 +232,7 @@ def main(args):
     valid_dataset = create_valid_dataset(
         VALID_DIR_IMAGES, 
         VALID_DIR_LABELS, 
-        IMAGE_WIDTH, 
-        IMAGE_HEIGHT, 
+        IMAGE_SIZE, 
         CLASSES,
         square_training=args['square_training']
     )
@@ -336,7 +333,7 @@ def main(args):
             model, device_ids=[args['gpu']]
         )
     torchinfo.summary(
-        model, device=DEVICE,input_size=(BATCH_SIZE, 3, IMAGE_HEIGHT, IMAGE_WIDTH)
+        model, device=DEVICE,input_size=(BATCH_SIZE, 3, IMAGE_SIZE, IMAGE_SIZE)
     )
     # Total parameters and trainable parameters.
     total_params = sum(p.numel() for p in model.parameters())

--- a/train.py
+++ b/train.py
@@ -145,6 +145,15 @@ def parse_opt():
             and also loads the otpimizer state dictionary'
     )
     parser.add_argument(
+        '-st', '--square-training',
+        dest='square_training',
+        action='store_true',
+        help='Resize images to square shape instead of aspect ratio resizing \
+              for single image training. For mosaic training, this resizes \
+              single images to square shape first then puts them on a \
+              square canvas.'
+    )
+    parser.add_argument(
         '--world-size', 
         default=1, 
         type=int, 
@@ -213,14 +222,22 @@ def main(args):
     IMAGE_HEIGHT = args['img_size']
     
     train_dataset = create_train_dataset(
-        TRAIN_DIR_IMAGES, TRAIN_DIR_LABELS,
-        IMAGE_WIDTH, IMAGE_HEIGHT, CLASSES,
+        TRAIN_DIR_IMAGES, 
+        TRAIN_DIR_LABELS,
+        IMAGE_WIDTH, 
+        IMAGE_HEIGHT, 
+        CLASSES,
         use_train_aug=args['use_train_aug'],
         no_mosaic=args['no_mosaic'],
+        square_training=args['square_training']
     )
     valid_dataset = create_valid_dataset(
-        VALID_DIR_IMAGES, VALID_DIR_LABELS, 
-        IMAGE_WIDTH, IMAGE_HEIGHT, CLASSES,
+        VALID_DIR_IMAGES, 
+        VALID_DIR_LABELS, 
+        IMAGE_WIDTH, 
+        IMAGE_HEIGHT, 
+        CLASSES,
+        square_training=args['square_training']
     )
     print('Creating data loaders')
     if args['distributed']:

--- a/train.py
+++ b/train.py
@@ -487,7 +487,8 @@ def main(args):
                 loss_rpn_list,
                 stats[1],
                 stats[0],
-                val_pred_image
+                val_pred_image,
+                IMAGE_SIZE
             )
 
         # Save the current epoch model state. This can be used 

--- a/utils/general.py
+++ b/utils/general.py
@@ -82,7 +82,6 @@ def show_tranformed_image(train_loader, device, classes, colors):
     This function shows the transformed images from the `train_loader`.
     Helps to check whether the tranformed images along with the corresponding
     labels are correct or not.
-    
     """
     if len(train_loader) > 0:
         for i in range(2):

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import wandb
 import cv2
+import numpy as np
 
 from torch.utils.tensorboard.writer import SummaryWriter
 
@@ -127,6 +128,15 @@ def csv_log(
         header=False
     )
 
+def overlay_on_canvas(bg, image):
+    bg_copy = bg.copy()
+    h, w = bg.shape[:2]
+    h1, w1 = image.shape[:2]
+    # Center of canvas (background).
+    cx, cy = (h - h1) // 2, (w - w1) // 2
+    bg_copy[cy:cy + h1, cx:cx + w1] = image
+    return bg_copy * 255.
+
 def wandb_log(
     epoch_loss, 
     loss_list_batch,
@@ -136,7 +146,8 @@ def wandb_log(
     loss_rpn_list,
     val_map_05, 
     val_map,
-    val_pred_image
+    val_pred_image,
+    image_size
 ):
     """
     :param epoch_loss: Single loss value for the current epoch.
@@ -171,26 +182,39 @@ def wandb_log(
         {'val_map_05': val_map_05}
     )
 
+    bg = np.full((image_size * 2, image_size * 2, 3), 114, dtype=np.float32)
+
     if len(val_pred_image) == 1:
-        log_image = val_pred_image[0]
+        log_image = overlay_on_canvas(bg, val_pred_image[0])
         wandb.log({'predictions': [wandb.Image(log_image)]})
 
     if len(val_pred_image) == 2:
-        log_image = cv2.hconcat([val_pred_image[0], val_pred_image[1]])
+        log_image = cv2.hconcat(
+            [
+                overlay_on_canvas(bg, val_pred_image[0]), 
+                overlay_on_canvas(bg, val_pred_image[1])
+            ]
+        )
         wandb.log({'predictions': [wandb.Image(log_image)]})
 
     if len(val_pred_image) > 2 and len(val_pred_image) <= 8:
-        log_image = val_pred_image[0]
+        log_image = overlay_on_canvas(bg, val_pred_image[0])
         for i in range(len(val_pred_image)-1):
-            log_image = cv2.hconcat([log_image, val_pred_image[i+1]])
+            log_image = cv2.hconcat([
+                log_image, 
+                overlay_on_canvas(bg, val_pred_image[i+1])
+            ])
         wandb.log({'predictions': [wandb.Image(log_image)]})
     
     if len(val_pred_image) > 8:
-        log_image = val_pred_image[0]
+        log_image = overlay_on_canvas(bg, val_pred_image[0])
         for i in range(len(val_pred_image)-1):
             if i == 7:
                 break
-            log_image = cv2.hconcat([log_image, val_pred_image[i-1]])
+            log_image = cv2.hconcat([
+                log_image, 
+                overlay_on_canvas(bg, val_pred_image[i-1])
+            ])
         wandb.log({'predictions': [wandb.Image(log_image)]})
 
 def wandb_save_model(model_dir):

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -1,4 +1,5 @@
 import albumentations as A
+import numpy as np
 
 from albumentations.pytorch import ToTensorV2
 from torchvision import transforms as transforms
@@ -48,7 +49,7 @@ def transform_mosaic(mosaic, boxes, img_size=640):
     ])
     sample = aug(image=mosaic)
     resized_mosaic = sample['image']
-    transformed_boxes = (boxes / mosaic.shape[0]) * resized_mosaic.shape[1]
+    transformed_boxes = (np.array(boxes) / mosaic.shape[0]) * resized_mosaic.shape[1]
     for box in transformed_boxes:
         # Bind all boxes to correct values. This should work correctly most of
         # of the time. There will be edge cases thought where this code will

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -33,6 +33,37 @@ def get_train_transform():
         'label_fields': ['labels']
     })
 
+def transform_mosaic(mosaic, boxes, img_size=640):
+    """
+    Resizes the `mosaic` image to `img_size` which is the desired image size
+    for the neural network input. Also transforms the `boxes` according to the
+    `img_size`.
+
+    :param mosaic: The mosaic image, Numpy array.
+    :param boxes: Boxes Numpy.
+    :param img_resize: Desired resize.
+    """
+    aug = A.Compose(
+        [A.Resize(img_size, img_size, always_apply=True, p=1.0)
+    ])
+    sample = aug(image=mosaic)
+    resized_mosaic = sample['image']
+    transformed_boxes = (boxes / mosaic.shape[0]) * resized_mosaic.shape[1]
+    for box in transformed_boxes:
+        # Bind all boxes to correct values. This should work correctly most of
+        # of the time. There will be edge cases thought where this code will
+        # mess things up. The best thing is to prepare the dataset as well as 
+        # as possible.
+        if box[2] - box[0] <= 1.0:
+            box[2] = box[2] + (1.0 - (box[2] - box[0]))
+            if box[2] >= float(resized_mosaic.shape[1]):
+                box[2] = float(resized_mosaic.shape[1])
+        if box[3] - box[1] <= 1.0:
+            box[3] = box[3] + (1.0 - (box[3] - box[1]))
+            if box[3] >= float(resized_mosaic.shape[0]):
+                box[3] = float(resized_mosaic.shape[0])
+    return resized_mosaic, transformed_boxes
+
 # Define the validation transforms
 def get_valid_transform():
     return A.Compose([


### PR DESCRIPTION
1. Non-mosaic training now carry out aspect ratio resizing. Better performance than square training. Can use `--square-training` for square resizing.
2. Mosaic augmentation according to Ultralytics YOLOv5 now. But requires a lot more data. Smaller models tend to perform less effectively now. Can do `square-training` along with mosaic which helps smaller models also.
3. With aspect ratio resizing and mosaic (default training settings) larger models can be trained much longer without overfitting.
4. A few other minor changes.