### PR TITLE
Fix loading dataset

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -94,7 +94,8 @@ if __name__ == '__main__':
             COCO_91_CLASSES = data_configs['COCO_91_CLASSES']
             valid_dataset = create_valid_dataset(
                 VALID_DIR_IMAGES, VALID_DIR_LABELS, 
-                IMAGE_WIDTH, IMAGE_HEIGHT, COCO_91_CLASSES
+                IMAGE_WIDTH, IMAGE_HEIGHT, COCO_91_CLASSES,
+                discard_negative=args["discard_negative"]
             )
 
     # Load weights.
@@ -104,7 +105,8 @@ if __name__ == '__main__':
         model.load_state_dict(checkpoint['model_state_dict'])
         valid_dataset = create_valid_dataset(
             VALID_DIR_IMAGES, VALID_DIR_LABELS, 
-            IMAGE_WIDTH, IMAGE_HEIGHT, CLASSES
+            IMAGE_WIDTH, IMAGE_HEIGHT, CLASSES,
+            discard_negative=args["discard_negative"]
         )
     model.to(DEVICE).eval()
     

--- a/train.py
+++ b/train.py
@@ -117,6 +117,12 @@ def parse_opt():
         help='pass this to not to use mosaic augmentation'
     )
     parser.add_argument(
+        '-dn', '--discard-negative', 
+        dest='discard_negative', 
+        action='store_true',
+        help='pass this to not to use mosaic augmentation'
+    )
+    parser.add_argument(
         '-uta', '--use-train-aug', 
         dest='use_train_aug', 
         action='store_true',
@@ -227,14 +233,16 @@ def main(args):
         CLASSES,
         use_train_aug=args['use_train_aug'],
         no_mosaic=args['no_mosaic'],
-        square_training=args['square_training']
+        square_training=args['square_training'],
+        discard_negative=args["discard_negative"]
     )
     valid_dataset = create_valid_dataset(
         VALID_DIR_IMAGES, 
         VALID_DIR_LABELS, 
         IMAGE_SIZE, 
         CLASSES,
-        square_training=args['square_training']
+        square_training=args['square_training'],
+        discard_negative=args["discard_negative"]
     )
     print('Creating data loaders')
     if args['distributed']:


### PR DESCRIPTION
Fixed loading dataset because images were discarded incorrectly [datasets.py#L87]( https://github.com/sovit-123/fasterrcnn-pytorch-training-pipeline/blob/main/datasets.py#L87). In particular in the original code, it is modified the list referenced by the for loop, this brings to unwanted behavior.
The code now behaves a little different when loading dataset: it first loads all the annotation files and, for each file, loads the corresponding image file specified in the `filename` tag in the annotation file.

Moreover, I've add a parameter to discard the negative examples (images without bonding-boxes/annotations) from the dataset. The default behavior is discard as in the original code. If negative example are keeped, for each negative example a bounding box of a single pixel is added.