### PR TITLE
Autocast warning

### DIFF
--- a/torch_utils/engine.py
+++ b/torch_utils/engine.py
@@ -48,7 +48,7 @@ def train_one_epoch(
         targets = [{k: v.to(device).to(torch.int64) for k, v in t.items()} for t in targets]
 
 
-        with torch.cuda.amp.autocast(enabled=scaler is not None):
+        with torch.autocast(device.type, enabled=scaler is not None):
             loss_dict = model(images, targets)
             losses = sum(loss for loss in loss_dict.values())
 


### PR DESCRIPTION
When using autocast as in line [engine.py#L51](https://github.com/sovit-123/fasterrcnn-pytorch-training-pipeline/blob/main/torch_utils/engine.py#L51) with device type "cpu" a warning is raised.

Using `torch.autocast(device_type, enabled ...)` resolve the warning.