### PR TITLE
[fix] pass patience arg to EarlyStopping class

### DIFF
--- a/train.py
+++ b/train.py
@@ -407,7 +407,7 @@ def main(args):
         scheduler = None
 
     save_best_model = SaveBestModel()
-    early_stopping = EarlyStopping()
+    early_stopping = EarlyStopping(patience=args['patience'])
 
     for epoch in range(start_epochs, NUM_EPOCHS):
         train_loss_hist.reset()


### PR DESCRIPTION
Hey mate,

you [recently](https://github.com/sovit-123/fasterrcnn-pytorch-training-pipeline/commit/3b7fdf1dc7b545087f6d4ce69b473820519a2425) introduced the patience cli arg together with the EarlyStopping feature.

Unfortunately, the patience argument is never passed to the EarlyStopping class and thus will never be respected.

This PR fixes that.

Thanks for the great project and your work, cheers